### PR TITLE
Remove link to chocoshop

### DIFF
--- a/packages/frontend/src/components/organisms/Contract.tsx
+++ b/packages/frontend/src/components/organisms/Contract.tsx
@@ -107,13 +107,6 @@ export const Contract: React.FC<ContractProps> = ({ nftContract, metadataList, d
               )}
             </Button>
           </div>
-          <div className="mr-2">
-            <a href={`https://shop.chocomint.app/${nftContract.chainId}/${nftContract.nftContractAddress}`}>
-              <Button type="tertiary" size="small" disabled={!deployedInternal}>
-                Chocoshop<span className="ml-2">🛒</span>
-              </Button>
-            </a>
-          </div>
         </div>
       </div>
       <div className="mb-8 relative">

--- a/packages/frontend/src/components/organisms/Contract.tsx
+++ b/packages/frontend/src/components/organisms/Contract.tsx
@@ -107,6 +107,13 @@ export const Contract: React.FC<ContractProps> = ({ nftContract, metadataList, d
               )}
             </Button>
           </div>
+          {/* <div className="mr-2">
+            <a href={`https://shop.chocomint.app/${nftContract.chainId}/${nftContract.nftContractAddress}`}>
+              <Button type="tertiary" size="small" disabled={!deployedInternal}>
+                Chocoshop<span className="ml-2">🛒</span>
+              </Button>
+            </a>
+          </div> */}
         </div>
       </div>
       <div className="mb-8 relative">


### PR DESCRIPTION
Chocoshopへの導線ボタンをコメントアウトした。
Chocoshopはバグ改修してv2としてまた復活する予定で、ボタンは使われていた可能性があるのですぐ戻せるようにコメントアウトした